### PR TITLE
fix map loading after migration from openfreemap to custom map backend

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -99,7 +99,7 @@ inject(() => {
         .catch(err => {
           console.error(`%c${name}%c: Failed to parse JSON: `, consoleStyle, '', err);
         });
-    } else if (contentType.includes('image/') && (!endpointName.includes('openfreemap'))) {
+    } else if (contentType.includes('image/') && (!endpointName.includes('openfreemap') && !endpointName.includes('maps'))) {
       // Fetch custom for all images but opensourcemap
 
       const blink = Date.now(); // Current time


### PR DESCRIPTION
the site now loads maps tiles from maps.wplace.live instead of openfreemap, so the logic for recognizing map requests started failing
fixes #51 