### PR TITLE
Fix issues with map loading

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -99,7 +99,7 @@ inject(() => {
         .catch(err => {
           console.error(`%c${name}%c: Failed to parse JSON: `, consoleStyle, '', err);
         });
-    } else if (contentType.includes('image/') && (!endpointName.includes('openfreemap'))) {
+    } else if (contentType.includes('image/') && (!endpointName.includes('maps.wplace.live'))) {
       // Fetch custom for all images but opensourcemap
 
       const blink = Date.now(); // Current time


### PR DESCRIPTION
Wplace recently moved away from openfreemap to their own hosting, which causes the map to not load with the userscript enabled. This updates the line in main.js that checks for "openfreemap" and replaces the string with "maps.wplace.live". The map loads fine with this fix.