### PR TITLE
Take coords from filename

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -486,8 +486,8 @@ function buildOverlayMain() {
       .addInputFile({'id': 'bm-input-file-template', 'textContent': 'Upload Template', 'accept': 'image/png, image/jpeg, image/webp, image/bmp, image/gif'}, (_,__,input,___) => {
           input.addEventListener('change', (e) => {
               const file = e.target.files[0];
-              const coordsMatch = file.name.match(/(?:.*\D)?(\d+)\D+(\d+)\D+(\d+)\D+(\d+).*?/);
-              if (coordsMatch) {
+              const coordsMatch = file.name.match(/(?:.*\D)?(\d{1,4})\D+(\d{1,4})\D+(\d{1,3})\D+(\d{1,3}).*/);
+              if (coordsMatch && coordsMatch[0] === file.name) {
                   document.querySelector('#bm-input-tx').value = coordsMatch[1];
                   document.querySelector('#bm-input-ty').value = coordsMatch[2];
                   document.querySelector('#bm-input-px').value = coordsMatch[3];

--- a/src/main.js
+++ b/src/main.js
@@ -486,7 +486,7 @@ function buildOverlayMain() {
       .addInputFile({'id': 'bm-input-file-template', 'textContent': 'Upload Template', 'accept': 'image/png, image/jpeg, image/webp, image/bmp, image/gif'}, (_,__,input,___) => {
           input.addEventListener('change', (e) => {
               const file = e.target.files[0];
-              const coordsMatch = file.name.match(/.*\D(\d+)\D+(\d+)\D+(\d+)\D+(\d+).*?/);
+              const coordsMatch = file.name.match(/(?:.*\D)?(\d+)\D+(\d+)\D+(\d+)\D+(\d+).*?/);
               if (coordsMatch) {
                   document.querySelector('#bm-input-tx').value = coordsMatch[1];
                   document.querySelector('#bm-input-ty').value = coordsMatch[2];

--- a/src/main.js
+++ b/src/main.js
@@ -483,7 +483,18 @@ function buildOverlayMain() {
         .addInput({'type': 'number', 'id': 'bm-input-px', 'placeholder': 'Px X', 'min': 0, 'max': 2047, 'step': 1, 'required': true}).buildElement()
         .addInput({'type': 'number', 'id': 'bm-input-py', 'placeholder': 'Px Y', 'min': 0, 'max': 2047, 'step': 1, 'required': true}).buildElement()
       .buildElement()
-      .addInputFile({'id': 'bm-input-file-template', 'textContent': 'Upload Template', 'accept': 'image/png, image/jpeg, image/webp, image/bmp, image/gif'}).buildElement()
+      .addInputFile({'id': 'bm-input-file-template', 'textContent': 'Upload Template', 'accept': 'image/png, image/jpeg, image/webp, image/bmp, image/gif'}, (_,__,input,___) => {
+          input.addEventListener('change', (e) => {
+              const file = e.target.files[0];
+              const coordsMatch = file.name.match(/.*\D(\d+)\D+(\d+)\D+(\d+)\D+(\d+).*?/);
+              if (coordsMatch) {
+                  document.querySelector('#bm-input-tx').value = coordsMatch[1];
+                  document.querySelector('#bm-input-ty').value = coordsMatch[2];
+                  document.querySelector('#bm-input-px').value = coordsMatch[3];
+                  document.querySelector('#bm-input-py').value = coordsMatch[4];
+              }
+          })
+      }).buildElement()
       .addDiv({'id': 'bm-contain-buttons-template'})
         .addButton({'id': 'bm-button-enable', 'textContent': 'Enable'}, (instance, button) => {
           button.onclick = () => {


### PR DESCRIPTION
* closes #72

I think this is the best regex that works. You can copy the coords from clicking on the top left corner and paste into image file name and it still works, e.g. `alice Tl X 797, Tl Y 775, Px X 174, Px Y 259.png` is valid file name but anything with 4 numbers separated by something not number works

edit: noticed that a filename that is only the coords didn't work. Files like `123 345 567 78.png` should work now