### PR TITLE
Externally hosted JSON storage

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -524,6 +524,76 @@ function buildOverlayMain() {
           }
         }).buildElement()
       .buildElement()
+          .addHr({id: "bm-json-hr"}).buildElement()
+    .addInput({ id: "bm-import-url-input", type: "text", placeholder: "URL to import from" })
+    .buildElement()
+    .addDiv({id: "bm-json-buttons"})
+    .addButton({ id: "bm-button-import", textContent: "Import JSON" }, (instance, button) => {
+      button.onclick = async () => {
+        const importURL = document.querySelector("#bm-import-url-input").value;
+        if (!importURL) {
+          instance.handleDisplayStatus(`No import url provided!`);
+          return;
+        }
+        const response = await fetch(importURL);
+        if (!response) {
+          // Got no response from the fetched location, website at url likely doesn't exist
+          instance.handleDisplayError(
+            "No data was found at given url, are you sure you inputted it correctly?"
+          );
+          return;
+        }
+        switch (response.status) {
+          case 200: // 200: OK, website returned a normal response
+            const responseJSON = await response.json();
+            if (await templateManager.importJSON(responseJSON))
+              instance.handleDisplayStatus("Successfully imported template!");
+            else
+              instance.handleDisplayError(
+                "An error occured when importing template, provided data may be malformed"
+              );
+            console.log(responseJSON);
+            break;
+          case 404: // 404: NOT FOUND, the requested webpage doesn't exist
+            instance.handleDisplayError(
+              "No data was found at given url, are you sure you inputted it correctly?"
+            );
+            break;
+          case 403: // 403: FORBIDDEN, the requested website disallowed access to the resource
+            instance.handleDisplayError("Access to the url location was denied by the url's host.");
+            break;
+          case 401: // 401: UNAUTHORIZED, the requested required authorisation, which is missing
+            instance.handleDisplayError("Access to the url location was denied by the url's host.");
+            break;
+          default: // Any other status code
+            instance.handleDisplayError("Unknown error occured during fetch of imported JSON!");
+            break;
+        }
+      };
+    })
+    .buildElement()
+    .addButton({ id: "bm-button-export", textContent: "Export JSON" }, (instance, button) => {
+      button.onclick = () => {
+        if (!instance.apiManager?.templateManager?.templatesJSON) {
+          instance.handleDisplayError("No templates are currently loaded!");
+          return;
+        }
+        try {
+          const jsonString = JSON.stringify(instance.apiManager?.templateManager?.templatesJSON);
+          const blob = new Blob([jsonString], { type: "application/json" });
+          const url = URL.createObjectURL(blob); // Create a web-accessible link for the templatesJSON resource (necessary for it to be downloaded)
+          const anchor = document.createElement("a");
+          anchor.download = "ExportJson.json"; // Default fileName of download file
+          anchor.href = url; // Set the resource / download link
+          anchor.click(); // Simulate clicking on a download link (starts the download)
+          URL.revokeObjectURL(url); // Free the URL from memory as it's unnecessary now
+        } catch (err) {
+          instance.handleDisplayError("An error occurded while exporting the templates: ", err);
+        }
+      };
+    })
+    .buildElement()
+    .buildElement()
       .addTextarea({'id': overlayMain.outputStatusId, 'placeholder': `Status: Sleeping...\nVersion: ${version}`, 'readOnly': true}).buildElement()
       .addDiv({'id': 'bm-contain-buttons-action'})
         .addDiv()

--- a/src/overlay.css
+++ b/src/overlay.css
@@ -171,6 +171,29 @@ div:has(> #bm-button-teleport) {
   vertical-align: bottom;
 }
 
+#bm-json-hr{
+  margin: 7px 0;
+}
+
+#bm-json-buttons{
+  display: flex;
+  flex-direction: row;
+  gap: 1.6ch;
+  align-items: center;
+  width: 100%;
+}
+
+#bm-import-url-input{
+  margin: 5px 0;
+  border-radius: 30px;
+  font-size: small;
+  padding: 0.5ch;
+  width: 100%;
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+
+
 /* Tile (x, y) & Pixel (x, y) input fields */
 #bm-contain-coords input[type="number"] {
   appearance: auto;

--- a/src/templateManager.js
+++ b/src/templateManager.js
@@ -305,21 +305,28 @@ export default class TemplateManager {
     return await canvas.convertToBlob({ type: 'image/png' });
   }
 
-  /** Imports the JSON object, and appends it to any JSON object already loaded
+/** Imports the JSON object, and appends it to any JSON object already loaded. Returns a Promise<boolean> indicating whether or not the importing succeeded
    * @param {string} json - The JSON string to parse
    */
   importJSON(json) {
 
     console.log(`Importing JSON...`);
     console.log(json);
+    console.log(json["whoami"]);
+    if (!json.hasOwnProperty("whoami")) {
+      // Return false if incorrect / malformed data is provided
+      return false;
+    }
 
     // If the passed in JSON is a Blue Marble template object...
-    if (json?.whoami == 'BlueMarble') {
-      this.#parseBlueMarble(json); // ...parse the template object as Blue Marble
+    if (json["whoami"] == "BlueMarble") {
+      return this.#parseBlueMarble(json); // ...parse the template object as Blue Marble
     }
+    return false;
   }
 
   /** Parses the Blue Marble JSON object
+  /** Parses the Blue Marble JSON object. Returns a boolean indicating whether or not the parsing succeeded
    * @param {string} json - The JSON string to parse
    * @since 0.72.13
    */
@@ -327,53 +334,81 @@ export default class TemplateManager {
 
     console.log(`Parsing BlueMarble...`);
 
-    const templates = json.templates;
+    if (!json.hasOwnProperty("templates"))
+      // Return false if incorrect / malformed data is provided
+      return false;
+
+    const templates = json["templates"];
+
+    if (typeof templates !== "object")
+      // Return false if incorrect / malformed data is provided
+      return false;
 
     console.log(`BlueMarble length: ${Object.keys(templates).length}`);
 
-    if (Object.keys(templates).length > 0) {
+    for (const templateKey in templates) {
 
-      for (const template in templates) {
+      const templateValue = templates[templateKey];
+      console.log(templateKey);
 
-        const templateKey = template;
-        const templateValue = templates[template];
-        console.log(templateKey);
+      const templateKeyArray = templateKey.split(" "); // E.g., "0 $Z" -> ["0", "$Z"]
+      const sortID = Number(templateKeyArray?.[0]); // Sort ID of the template
+      const authorID = templateKeyArray?.[1] || "0"; // User ID of the person who exported the template
 
-        if (templates.hasOwnProperty(template)) {
+      if (!templateValue.hasOwnProperty("name") || typeof templateValue["name"] !== "string") return false; // Return false if incorrect / malformed data is provided
 
-          const templateKeyArray = templateKey.split(' '); // E.g., "0 $Z" -> ["0", "$Z"]
-          const sortID = Number(templateKeyArray?.[0]); // Sort ID of the template
-          const authorID = templateKeyArray?.[1] || '0'; // User ID of the person who exported the template
-          const displayName = templateValue.name || `Template ${sortID || ''}`; // Display name of the template
-          //const coords = templateValue?.coords?.split(',').map(Number); // "1,2,3,4" -> [1, 2, 3, 4]
-          const tilesbase64 = templateValue.tiles;
-          const templateTiles = {}; // Stores the template bitmap tiles for each tile.
+      const displayName = templateValue["name"] || `Template ${sortID || ""}`; // Display name of the template
+      // const coords = templateValue?.coords?.split(',').map(Number); // "1,2,3,4" -> [1, 2, 3, 4]
 
-          for (const tile in tilesbase64) {
-            console.log(tile);
-            if (tilesbase64.hasOwnProperty(tile)) {
-              const encodedTemplateBase64 = tilesbase64[tile];
-              const templateUint8Array = base64ToUint8(encodedTemplateBase64); // Base 64 -> Uint8Array
+      if (!templateValue.hasOwnProperty("tiles") || Array.isArray(templateValue["tiles"])) return false; // Return false if incorrect / malformed data is provided
 
-              const templateBlob = new Blob([templateUint8Array], { type: "image/png" }); // Uint8Array -> Blob
-              const templateBitmap = await createImageBitmap(templateBlob) // Blob -> Bitmap
-              templateTiles[tile] = templateBitmap;
-            }
-          }
+      const tilesbase64 = templateValue["tiles"];
+      const templateTiles = {}; // Stores the template bitmap tiles for each tile.
 
-          // Creates a new Template class instance
-          const template = new Template({
-            displayName: displayName,
-            sortID: sortID || this.templatesArray?.length || 0,
-            authorID: authorID || '',
-            //coords: coords
-          });
-          template.chunked = templateTiles;
-          this.templatesArray.push(template);
-          console.log(this.templatesArray);
-          console.log(`^^^ This ^^^`);
-        }
+      for (const tile in tilesbase64) {
+        console.log(tile);
+        if (!tilesbase64.hasOwnProperty(tile)) return false; // Return false if incorrect / malformed data is provided
+        const encodedTemplateBase64 = tilesbase64[tile];
+        const templateUint8Array = base64ToUint8(encodedTemplateBase64); // Base 64 -> Uint8Array
+
+        const templateBlob = new Blob([templateUint8Array], { type: "image/png" }); // Uint8Array -> Blob
+        const templateBitmap = await createImageBitmap(templateBlob); // Blob -> Bitmap
+        templateTiles[tile] = templateBitmap;
       }
+
+      // Creates a new Template class instance
+      const template = new Template({
+        displayName: displayName,
+        sortID: sortID || this.templatesArray?.length || 0,
+        authorID: authorID || "",
+        //coords: coords
+      });
+      template.chunked = templateTiles;
+      this.templatesArray.push(template);
+      console.log(this.templatesArray);
+      console.log(`^^^ This ^^^`);
+
+      // Creates the JSON object if it does not already exist
+      if (!this.templatesJSON) {
+        this.templatesJSON = await this.createJSON();
+        console.log(`Creating JSON...`);
+      }
+
+      if (!templateValue.hasOwnProperty("coords") || typeof templateValue.coords !== "string")
+        // Return false if incorrect / malformed data is provided
+        return false;
+
+      // Update the current JSON object with the new template
+      this.templatesJSON.templates[`${sortID} ${authorID}`] = {
+        name: displayName,
+        coords: templateValue["coords"],
+        enabled: true,
+        tiles: tilesbase64, // Stores the chunked tile buffers
+      };
+      
+      this.#storeTemplates(); // Update the userscript storage
+
+      return true;
     }
   }
 


### PR DESCRIPTION
Added the ability to export to externally hosted storage for JSON data and import data from that URL with a button, allowing for easier template sharing and potential for self-updating templates

Changes:

- Return boolean in importJson and parseBlueMarble that is true when import / parse succeeds and false if not;
- Updating templatesJson in parseBlueMarble;
-  Storing templatesJson in parseBlueMarble;
-  Input for url from which to import JSON data;
-  Button for importing JSON data + error handling;
-  Button for exporting JSON data (via file download) + error handling;
-  Style / CSS changes for the new elements;
