### PR TITLE
feat: Add new official Blue Marble website and update documentation

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -50,7 +50,7 @@
 <h1>Contributing</h1>
 <a href="https://github.com/SwingTheVine/Wplace-BlueMarble/blob/main/LICENSE.txt" target="_blank" rel="noopener noreferrer"><img alt="Software License: MPL-2.0" src="https://img.shields.io/badge/Software_License-MPL--2.0-slateblue?style=flat"></a>
 <p>
-  Thank you for wanting to contribute to the userscript "Blue Marble"! It means a lot to me that someone likes my project enough to want to help it grow. If you haven't already done so, consider joining our Discord. You can ask questions about the userscript there and receive feedback.
+  Thank you for wanting to contribute to the userscript "Blue Marble"! It means a lot to me that someone likes my project enough to want to help it grow. If you haven't already done so, consider joining our Discord. You can ask questions about the userscript there and receive feedback. You can also visit the <a href="https://bluemarble.camilledaguin.fr/" target="_blank" rel="noopener noreferrer">official Blue Marble website</a> for more information.
   <br>
   <b>Note</b>: If you are using AI, and you want to tell the AI how the codebase files are related to each-other, go to the <code>Class diagram of relationships for Blue Marble</code> diagram in the chart section of this file. Copy the chart, and give it to the AI.
 </p>

--- a/docs/CREDITS.md
+++ b/docs/CREDITS.md
@@ -18,10 +18,8 @@
 ---------------------------------------------------
 
 "Blue Marble" is made by SwingTheVine
-The Blue Marble Website is made by Camille Daguin
+The [Blue Marble Website](https://bluemarble.camilledaguin.fr/) is made by Camille Daguin
 The favicon "Blue Marble" is owned by NASA
-
-Official Website: https://bluemarble.camilledaguin.fr/
 
 Special Thanks:
 * nof, [darkness](https://github.com/TouchedByDarkness) for creating similar userscripts!

--- a/docs/CREDITS.md
+++ b/docs/CREDITS.md
@@ -18,8 +18,10 @@
 ---------------------------------------------------
 
 "Blue Marble" is made by SwingTheVine
-
+The Blue Marble Website is made by Camille Daguin
 The favicon "Blue Marble" is owned by NASA
+
+Official Website: https://bluemarble.camilledaguin.fr/
 
 Special Thanks:
 * nof, [darkness](https://github.com/TouchedByDarkness) for creating similar userscripts!

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@
 </table>
 
 <h1>Blue Marble</h1>
+<a href="https://bluemarble.camilledaguin.fr/" target="_blank" rel="noopener noreferrer"><img alt="Site Web Officiel" src="https://img.shields.io/badge/Site_Web_Officiel-Blue_Marble-blue?style=flat&logo=globe&logoColor=white"></a>
 <a href="https://wplacestatus.sobakintech.xyz" target="_blank" rel="noopener noreferrer"><img alt="Wplace Status" src="https://wplacestatus.sobakintech.xyz/api/badge/15/status"></a>
 <a href="" target="_blank" rel="noopener noreferrer"><img alt="Latest Version" src="https://img.shields.io/badge/Latest_Version-0.80.0-lightblue?style=flat"></a>
 <a href="https://github.com/SwingTheVine/Wplace-BlueMarble/releases" target="_blank" rel="noopener noreferrer"><img alt="Latest Release" src="https://img.shields.io/github/v/release/SwingTheVine/Wplace-BlueMarble?sort=semver&style=flat&label=Latest%20Release&color=blue"></a>
@@ -62,6 +63,12 @@
 <h2>Quick Guide</h2>
 <p>
   Press the arrows to reveal the option you want.
+  <details>
+    <summary>
+      <b>I want to visit the official Blue Marble website.</b> <sup>(Click to Expand)</sup>
+    </summary>
+    <a href="https://bluemarble.camilledaguin.fr/" target="_blank" rel="noopener noreferrer">Click here</a> to visit the official Blue Marble website.
+  </details>
   <details>
     <summary>
       <b>I want to download Blue Marble.</b> <sup>(Click to Expand)</sup>
@@ -106,7 +113,7 @@
     <li>Allowing you to use the eyedropper on the template image, provided the colors are correct</li>
     <li>...and more!</li>
   </ul>
-  If you like this userscript, please ⭐ the repository! If you wish to contribute to Blue Marble, check out the <a href="https://github.com/SwingTheVine/Wplace-BlueMarble/blob/main/docs/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">CONTRIBUTING.md</a> file in <code>docs/</code>.
+  If you like this userscript, please ⭐ the repository! For more information and updates, visit the <a href="https://bluemarble.camilledaguin.fr/" target="_blank" rel="noopener noreferrer">official Blue Marble website</a>. If you wish to contribute to Blue Marble, check out the <a href="https://github.com/SwingTheVine/Wplace-BlueMarble/blob/main/docs/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">CONTRIBUTING.md</a> file in <code>docs/</code>.
 
   <img alt="Showcase image of Blue Marble template" src="./assets/Showcase1.png">
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,12 +42,12 @@
 </table>
 
 <h1>Blue Marble</h1>
-<a href="https://bluemarble.camilledaguin.fr/" target="_blank" rel="noopener noreferrer"><img alt="Site Web Officiel" src="https://img.shields.io/badge/Site_Web_Officiel-Blue_Marble-blue?style=flat&logo=globe&logoColor=white"></a>
 <a href="https://wplacestatus.sobakintech.xyz" target="_blank" rel="noopener noreferrer"><img alt="Wplace Status" src="https://wplacestatus.sobakintech.xyz/api/badge/15/status"></a>
 <a href="" target="_blank" rel="noopener noreferrer"><img alt="Latest Version" src="https://img.shields.io/badge/Latest_Version-0.80.0-lightblue?style=flat"></a>
 <a href="https://github.com/SwingTheVine/Wplace-BlueMarble/releases" target="_blank" rel="noopener noreferrer"><img alt="Latest Release" src="https://img.shields.io/github/v/release/SwingTheVine/Wplace-BlueMarble?sort=semver&style=flat&label=Latest%20Release&color=blue"></a>
 <a href="https://github.com/SwingTheVine/Wplace-BlueMarble/blob/main/LICENSE.txt" target="_blank" rel="noopener noreferrer"><img alt="Software License: MPL-2.0" src="https://img.shields.io/badge/Software_License-MPL--2.0-slateblue?style=flat"></a>
 <a href="https://discord.gg/tpeBPy46hf" target="_blank" rel="noopener noreferrer"><img alt="Contact Me" src="https://img.shields.io/badge/Contact_Me-gray?style=flat&logo=Discord&logoColor=white&logoSize=auto&labelColor=cornflowerblue"></a>
+<a href="https://bluemarble.camilledaguin.fr/" target="_blank" rel="noopener noreferrer"><img alt="Blue Marble Website" src="https://img.shields.io/badge/Official_Website-Camille_Daguin-blue?style=flat&logo=globe&logoColor=white"></a>
 <a href="" target="_blank" rel="noopener noreferrer"><img alt="WakaTime" src="https://img.shields.io/badge/Coding_Time-111hrs_12mins-blue?style=flat&logo=wakatime&logoColor=black&logoSize=auto&labelColor=white"></a>
 <a href="" target="_blank" rel="noopener noreferrer"><img alt="Total Patches" src="https://img.shields.io/badge/Total_Patches-494-black?style=flat"></a>
 <a href="" target="_blank" rel="noopener noreferrer"><img alt="Total Lines of Code" src="https://tokei.rs/b1/github/SwingTheVine/Wplace-BlueMarble?category=code"></a>

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,12 +65,6 @@
   Press the arrows to reveal the option you want.
   <details>
     <summary>
-      <b>I want to visit the official Blue Marble website.</b> <sup>(Click to Expand)</sup>
-    </summary>
-    <a href="https://bluemarble.camilledaguin.fr/" target="_blank" rel="noopener noreferrer">Click here</a> to visit the official Blue Marble website.
-  </details>
-  <details>
-    <summary>
       <b>I want to download Blue Marble.</b> <sup>(Click to Expand)</sup>
     </summary>
     <a href="#installation-instructions">Click here</a> to view the installation instructions.
@@ -101,6 +95,12 @@
     </summary>
     <a href="https://github.com/SwingTheVine/Wplace-BlueMarble/blob/main/docs/CONTRIBUTING.md">Click here</a> to read the contributing guidelines.
   </details>
+  <details>
+    <summary>
+      <b>I want to visit the website.</b> <sup>(Click to Expand)</sup>
+    </summary>
+    <a href="https://bluemarble.camilledaguin.fr/" target="_blank" rel="noopener noreferrer">Click here</a> to visit the official Blue Marble website.
+  </details>
 </p>
 
 <h2>Overview</h2>
@@ -113,7 +113,7 @@
     <li>Allowing you to use the eyedropper on the template image, provided the colors are correct</li>
     <li>...and more!</li>
   </ul>
-  If you like this userscript, please ⭐ the repository! For more information and updates, visit the <a href="https://bluemarble.camilledaguin.fr/" target="_blank" rel="noopener noreferrer">official Blue Marble website</a>. If you wish to contribute to Blue Marble, check out the <a href="https://github.com/SwingTheVine/Wplace-BlueMarble/blob/main/docs/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">CONTRIBUTING.md</a> file in <code>docs/</code>.
+  If you like this userscript, please ⭐ the repository! For more information and updates, visit the <a href="https://bluemarble.camilledaguin.fr/" target="_blank" rel="noopener noreferrer">Blue Marble website</a>. If you wish to contribute to Blue Marble, check out the <a href="https://github.com/SwingTheVine/Wplace-BlueMarble/blob/main/docs/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">CONTRIBUTING.md</a> file in <code>docs/</code>.
 
   <img alt="Showcase image of Blue Marble template" src="./assets/Showcase1.png">
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,5 +1,5 @@
 <h1>Reporting A Security Vulnerability</h1>
 <a href="" target="_blank" rel="noopener noreferrer"><img alt="CodeQL" src="https://github.com/SwingTheVine/Wplace-BlueMarble/actions/workflows/github-code-scanning/codeql/badge.svg"></a>
 <p>
-  Since this is a userscript, there will not be many vulnerabilities. The user is in charge of their own security, by choosing which scripts to run. Regardless, if you do find a security vulnerability in Blue Marble, please report it on the GitHub Security Advisory <a href="https://github.com/SwingTheVine/Wplace-BlueMarble/security/advisories/new">"Report a Vulnerability"</a> tab. For more information about Blue Marble, visit the <a href="https://bluemarble.camilledaguin.fr/" target="_blank" rel="noopener noreferrer">official website</a>.
+  Since this is a userscript, there will not be many vulnerabilities. The user is in charge of their own security, by choosing which scripts to run. Regardless, if you do find a security vulnerability in Blue Marble, please report it on the GitHub Security Advisory <a href="https://github.com/SwingTheVine/Wplace-BlueMarble/security/advisories/new">"Report a Vulnerability"</a> tab.
 </p>

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,5 +1,5 @@
 <h1>Reporting A Security Vulnerability</h1>
 <a href="" target="_blank" rel="noopener noreferrer"><img alt="CodeQL" src="https://github.com/SwingTheVine/Wplace-BlueMarble/actions/workflows/github-code-scanning/codeql/badge.svg"></a>
 <p>
-  Since this is a userscript, there will not be many vulnerabilities. The user is in charge of their own security, by choosing which scripts to run. Regardless, if you do find a security vulnerability in Blue Marble, please report it on the GitHub Security Advisory <a href="https://github.com/SwingTheVine/Wplace-BlueMarble/security/advisories/new">"Report a Vulnerability"</a> tab.
+  Since this is a userscript, there will not be many vulnerabilities. The user is in charge of their own security, by choosing which scripts to run. Regardless, if you do find a security vulnerability in Blue Marble, please report it on the GitHub Security Advisory <a href="https://github.com/SwingTheVine/Wplace-BlueMarble/security/advisories/new">"Report a Vulnerability"</a> tab. For more information about Blue Marble, visit the <a href="https://bluemarble.camilledaguin.fr/" target="_blank" rel="noopener noreferrer">official website</a>.
 </p>

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -3,6 +3,7 @@
     "include": ["src"],
     "exclude": ["node_modules", "build", "dist"]
   },
+  "homepage": "https://bluemarble.camilledaguin.fr/",
   "opts": {
     "destination": "docs",
     "template": "node_modules/minami",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "wplace-bluemarble",
   "version": "0.80.0",
   "type": "module",
+  "homepage": "https://bluemarble.camilledaguin.fr/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SwingTheVine/Wplace-BlueMarble.git"
+  },
   "scripts": {
     "build": "node build/build.js",
     "patch": "node build/patch.js && npm run build"

--- a/src/BlueMarble.meta.js
+++ b/src/BlueMarble.meta.js
@@ -7,7 +7,6 @@
 // @license      MPL-2.0
 // @supportURL   https://discord.gg/tpeBPy46hf
 // @homepageURL  https://bluemarble.camilledaguin.fr/
-// @website      https://bluemarble.camilledaguin.fr/
 // @icon         https://raw.githubusercontent.com/SwingTheVine/Wplace-BlueMarble/f3ee47c55505d29255b29e320891453884f13369/dist/assets/Favicon.png
 // @updateURL    https://raw.githubusercontent.com/SwingTheVine/Wplace-BlueMarble/main/dist/BlueMarble.user.js
 // @downloadURL  https://raw.githubusercontent.com/SwingTheVine/Wplace-BlueMarble/main/dist/BlueMarble.user.js

--- a/src/BlueMarble.meta.js
+++ b/src/BlueMarble.meta.js
@@ -6,7 +6,8 @@
 // @author       SwingTheVine
 // @license      MPL-2.0
 // @supportURL   https://discord.gg/tpeBPy46hf
-// @homepageURL  https://github.com/SwingTheVine/Wplace-BlueMarble
+// @homepageURL  https://bluemarble.camilledaguin.fr/
+// @website      https://bluemarble.camilledaguin.fr/
 // @icon         https://raw.githubusercontent.com/SwingTheVine/Wplace-BlueMarble/f3ee47c55505d29255b29e320891453884f13369/dist/assets/Favicon.png
 // @updateURL    https://raw.githubusercontent.com/SwingTheVine/Wplace-BlueMarble/main/dist/BlueMarble.user.js
 // @downloadURL  https://raw.githubusercontent.com/SwingTheVine/Wplace-BlueMarble/main/dist/BlueMarble.user.js

--- a/src/main.js
+++ b/src/main.js
@@ -536,6 +536,12 @@ function buildOverlayMain() {
               window.open('https://pepoafonso.github.io/color_converter_wplace/', '_blank', 'noopener noreferrer');
             });
           }).buildElement()
+          .addButton({'id': 'bm-button-website', 'className': 'bm-help', 'innerHTML': '🌐', 'title': 'Official Blue Marble Website'}, 
+            (instance, button) => {
+            button.addEventListener('click', () => {
+              window.open('https://bluemarble.camilledaguin.fr/', '_blank', 'noopener noreferrer');
+            });
+          }).buildElement()
         .buildElement()
         .addSmall({'textContent': 'Made by SwingTheVine', 'style': 'margin-top: auto;'}).buildElement()
       .buildElement()


### PR DESCRIPTION
Add newly created official Blue Marble website and update project documentation

- Add official website badge to README.md
- Include website link in Quick Guide section
- Add website creator credits in CREDITS.md
- Update CONTRIBUTING.md with website reference
- Add new official website URL: https://bluemarble.camilledaguin.fr/

This commit introduces the newly created official Blue Marble website and updates all documentation to reference it. The website provides a dedicated platform for Blue Marble users and information.