### PR TITLE
Run the userscript only when on wplace.live

### DIFF
--- a/src/BlueMarble.meta.js
+++ b/src/BlueMarble.meta.js
@@ -11,7 +11,7 @@
 // @updateURL    https://raw.githubusercontent.com/SwingTheVine/Wplace-BlueMarble/main/dist/BlueMarble.user.js
 // @downloadURL  https://raw.githubusercontent.com/SwingTheVine/Wplace-BlueMarble/main/dist/BlueMarble.user.js
 // @run-at       document-start
-// @match        *://*.wplace.live/*
+// @include     /^https:\/\/wplace\.live\/(?:\?.*)?$/
 // @grant        GM_getResourceText
 // @grant        GM_addStyle
 // @grant        GM.setValue


### PR DESCRIPTION
This small change changes the "match" statement for all subdomains and subdirectories to a regex based "include" statement. The statement has the script run on wplace.live, and wplace.live/? (for share links).

(fixes #109)