### PR TITLE
Add more color filter presets

### DIFF
--- a/src/Overlay.js
+++ b/src/Overlay.js
@@ -490,6 +490,22 @@ export default class Overlay {
     return this;
   }
 
+  addSelect(additionalProperties = {}, callback = () => {}) {
+    const properties = {}; // Shared <select> DOM properties
+
+    const select = this.#createElement('select', properties, additionalProperties); // Creates the <select> element
+    callback(this, select); // Runs any script passed in through the callback
+    return this;
+  }
+
+  addOption(additionalProperties = {}, callback = () => {}) {
+    const properties = {}; // Shared <option> DOM properties
+
+    const option = this.#createElement('option', properties, additionalProperties); // Creates the <option> element
+    callback(this, option); // Runs any script passed in through the callback
+    return this;
+  }
+
   /** Adds a `textarea` to the overlay.
    * This `textarea` element will have properties shared between all `textarea` elements in the overlay.
    * You can override the shared properties by using a callback.

--- a/src/apiManager.js
+++ b/src/apiManager.js
@@ -5,12 +5,12 @@
  */
 
 import TemplateManager from "./templateManager.js";
-import { consoleError, escapeHTML, numberToEncoded, serverTPtoDisplayTP } from "./utils.js";
+import { consoleError, escapeHTML, numberToEncoded, serverTPtoDisplayTP, colorpalette } from "./utils.js";
 
 export default class ApiManager {
 
   /** Constructor for ApiManager class
-   * @param {TemplateManager} templateManager 
+   * @param {TemplateManager} templateManager
    * @since 0.11.34
    */
   constructor(templateManager) {
@@ -72,7 +72,21 @@ export default class ApiManager {
             ));
           }
           this.templateManager.userID = dataJSON['id'];
-          
+
+          // Set the user's owned colors
+          // extraColorsBitmap is a 32-bit integer where the nth bit represents whether
+          // the user owns the color with id n+32 (paid colors start at 32)
+          for (let i = 0; i < 32; i++) {
+            const rgb = colorpalette[i + 32]?.rgb;
+            const key = `${rgb[0]},${rgb[1]},${rgb[2]}`;
+            if (dataJSON['extraColorsBitmap'] & (1 << i)) {
+              this.templateManager.ownedColors.set(key, true);
+            } else {
+              this.templateManager.ownedColors.set(key, false);
+            }
+          }
+          console.log('Owned colors:', this.templateManager.ownedColors);
+
           overlay.updateInnerHTML('bm-user-name', `Username: <b>${escapeHTML(dataJSON['name'])}</b>`); // Updates the text content of the username field
           overlay.updateInnerHTML('bm-user-droplets', `Droplets: <b>${new Intl.NumberFormat().format(dataJSON['droplets'])}</b>`); // Updates the text content of the droplets field
           overlay.updateInnerHTML('bm-user-nextlevel', `Next level in <b>${new Intl.NumberFormat().format(nextLevelPixels)}</b> pixel${nextLevelPixels == 1 ? '' : 's'}`); // Updates the text content of the next level field

--- a/src/main.js
+++ b/src/main.js
@@ -550,7 +550,7 @@ function buildOverlayMain() {
         }).buildElement()
       .buildElement()
       // Color filter UI
-      .addDiv({'id': 'bm-contain-colorfilter', 'style': 'max-height: 140px; overflow: auto; border: 1px solid rgba(255,255,255,0.1); padding: 4px; border-radius: 4px; display: none;'})
+      .addDiv({'id': 'bm-contain-colorfilter', 'style': 'height: 140px; max-height: fit-content; resize: vertical; overflow: auto; border: 1px solid rgba(255,255,255,0.1); padding: 4px; border-radius: 4px; display: none;'})
         .addDiv({'style': 'display: flex; gap: 6px; margin-bottom: 6px;'})
           .addButton({'id': 'bm-button-colors-enable-all', 'textContent': 'Enable All'}, (instance, button) => {
             button.onclick = () => {
@@ -568,6 +568,21 @@ function buildOverlayMain() {
               Object.values(t.colorPalette).forEach(v => v.enabled = false);
               buildColorFilterList();
               instance.handleDisplayStatus('Disabled all colors');
+            };
+          }).buildElement()
+        .buildElement()
+        .addDiv({'style': 'display: flex; gap: 6px; margin-bottom: 6px;'})
+          .addButton({'id': 'bm-button-colors-enable-owned', 'textContent': 'Enable owned'}, (instance, button) => {
+            button.onclick = () => {
+              const t = templateManager.templatesArray[0];
+              if (!t?.colorPalette) { return; }
+              for (const [rgb, owned] of templateManager.ownedColors) {
+                if (owned && t.colorPalette[rgb]) {
+                  t.colorPalette[rgb].enabled = true;
+                }
+              }
+              buildColorFilterList();
+              instance.handleDisplayStatus('Enabled owned colors');
             };
           }).buildElement()
           .addButton({'id': 'bm-button-colors-disable-unowned', 'textContent': 'Disable Unowned'}, (instance, button) => {

--- a/src/main.js
+++ b/src/main.js
@@ -570,6 +570,19 @@ function buildOverlayMain() {
               instance.handleDisplayStatus('Disabled all colors');
             };
           }).buildElement()
+          .addButton({'id': 'bm-button-colors-disable-unowned', 'textContent': 'Disable Unowned'}, (instance, button) => {
+            button.onclick = () => {
+              const t = templateManager.templatesArray[0];
+              if (!t?.colorPalette) { return; }
+              for (const [rgb, owned] of templateManager.ownedColors) {
+                if (!owned && t.colorPalette[rgb]) {
+                  t.colorPalette[rgb].enabled = false;
+                }
+              }
+              buildColorFilterList();
+              instance.handleDisplayStatus('Disabled unowned colors');
+            };
+          }).buildElement()
         .buildElement()
         .addDiv({'id': 'bm-colorfilter-list'}).buildElement()
       .buildElement()

--- a/src/main.js
+++ b/src/main.js
@@ -551,53 +551,39 @@ function buildOverlayMain() {
       .buildElement()
       // Color filter UI
       .addDiv({'id': 'bm-contain-colorfilter', 'style': 'height: 140px; max-height: fit-content; resize: vertical; overflow: auto; border: 1px solid rgba(255,255,255,0.1); padding: 4px; border-radius: 4px; display: none;'})
-        .addDiv({'style': 'display: flex; gap: 6px; margin-bottom: 6px;'})
-          .addButton({'id': 'bm-button-colors-enable-all', 'textContent': 'Enable All'}, (instance, button) => {
-            button.onclick = () => {
-              const t = templateManager.templatesArray[0];
-              if (!t?.colorPalette) { return; }
-              Object.values(t.colorPalette).forEach(v => v.enabled = true);
-              buildColorFilterList();
-              instance.handleDisplayStatus('Enabled all colors');
-            };
-          }).buildElement()
-          .addButton({'id': 'bm-button-colors-disable-all', 'textContent': 'Disable All'}, (instance, button) => {
-            button.onclick = () => {
-              const t = templateManager.templatesArray[0];
-              if (!t?.colorPalette) { return; }
-              Object.values(t.colorPalette).forEach(v => v.enabled = false);
-              buildColorFilterList();
-              instance.handleDisplayStatus('Disabled all colors');
-            };
-          }).buildElement()
-        .buildElement()
-        .addDiv({'style': 'display: flex; gap: 6px; margin-bottom: 6px;'})
-          .addButton({'id': 'bm-button-colors-enable-owned', 'textContent': 'Enable owned'}, (instance, button) => {
-            button.onclick = () => {
-              const t = templateManager.templatesArray[0];
-              if (!t?.colorPalette) { return; }
-              for (const [rgb, owned] of templateManager.ownedColors) {
-                if (owned && t.colorPalette[rgb]) {
-                  t.colorPalette[rgb].enabled = true;
+        .addSelect({'style': 'background-color: #144eb9; width: 100%; margin-bottom: 6px;'}, (instance, select) => {
+          select.onchange = () => {
+            console.log('select change:', select.value);
+            const t = templateManager.templatesArray[0];
+            if (!t?.colorPalette) { return; }
+            const value = select.value;
+            switch (value) {
+              case 'all':
+              case 'none':
+                Object.values(t.colorPalette).forEach(v => v.enabled = value === 'all');
+                instance.handleDisplayStatus(`${value === 'all' ? 'Enabled' : 'Disabled'} all colors`);
+                break;
+              case 'owned':
+              case 'bought':
+                Object.values(t.colorPalette).forEach(v => v.enabled = value === 'owned');
+                for (const [rgb, owned] of templateManager.ownedColors) {
+                  if (t.colorPalette[rgb]) {
+                    t.colorPalette[rgb].enabled = owned;
+                  }
                 }
-              }
-              buildColorFilterList();
-              instance.handleDisplayStatus('Enabled owned colors');
-            };
-          }).buildElement()
-          .addButton({'id': 'bm-button-colors-disable-unowned', 'textContent': 'Disable Unowned'}, (instance, button) => {
-            button.onclick = () => {
-              const t = templateManager.templatesArray[0];
-              if (!t?.colorPalette) { return; }
-              for (const [rgb, owned] of templateManager.ownedColors) {
-                if (!owned && t.colorPalette[rgb]) {
-                  t.colorPalette[rgb].enabled = false;
-                }
-              }
-              buildColorFilterList();
-              instance.handleDisplayStatus('Disabled unowned colors');
-            };
-          }).buildElement()
+                instance.handleDisplayStatus(value === 'owned' ? 'Enabled all owned colors' : 'Enabled owned premium colors');
+                break;
+              default:
+                console.warn(`Unknown color filter value: ${value}`);
+                return;
+            }
+            buildColorFilterList();
+          };
+        })
+          .addOption({'value': 'all', 'textContent': 'All'}).buildElement()
+          .addOption({'value': 'owned', 'textContent': 'Owned', 'title': 'Displays all owned colors'}).buildElement()
+          .addOption({'value': 'bought', 'textContent': 'Bought', 'title': 'Displays only owned premium colors'}).buildElement()
+          .addOption({'value': 'none', 'textContent': 'None'}).buildElement()
         .buildElement()
         .addDiv({'id': 'bm-colorfilter-list'}).buildElement()
       .buildElement()

--- a/src/main.js
+++ b/src/main.js
@@ -210,6 +210,17 @@ overlayMain.handleDrag('#bm-overlay', '#bm-bar-drag'); // Creates dragging capab
 
 apiManager.spontaneousResponseListener(overlayMain); // Reads spontaneous fetch responces
 
+// Force-load /me once on startup so user info and owned colors are available
+inject(() => {
+  fetch('https://backend.wplace.live/me', { credentials: 'include' })
+    .then(r => r.ok ? r.json() : null)
+    .then(json => {
+      if (!json) { return; }
+      window.postMessage({ source: 'blue-marble', endpoint: 'me', jsonData: json }, '*');
+    })
+    .catch(() => {});
+});
+
 observeBlack(); // Observes the black palette color
 
 consoleLog(`%c${name}%c (${version}) userscript has loaded!`, 'color: cornflowerblue;', '');

--- a/src/templateManager.js
+++ b/src/templateManager.js
@@ -62,6 +62,10 @@ export default class TemplateManager {
     this.templatesJSON = null; // All templates currently loaded (JSON)
     this.templatesShouldBeDrawn = true; // Should ALL templates be drawn to the canvas?
     this.tileProgress = new Map(); // Tracks per-tile progress stats {painted, required, wrong}
+
+    this.ownedColors = new Map() // Stores the colors owned by the user as 'r,g,b' -> boolean
+    // fyi i hate this and would rather the entire codebase use color ids instead of rgb strings,
+    // but i cant be bothered to refactor the entire codebase right now
   }
 
   /** Retrieves the pixel art canvas.


### PR DESCRIPTION
Closes #206 

- Replaces the 'Enable All' and 'Disable All' buttons with a dropdown, replaced by 'All' and 'None' options respectively
- Added two new filter presets 'Owned', which enables only the user's owned colors (free and paid), and 'Bought', which enables only the premium/paid colors that the user owns.
- Made the color filter area resizable for convenience
- This is just a proof of concept, someone else please polish/change the UI before merging. I'm not a UI guy

TODO:
- [ ] Documentation for new html functions

Side note:
Why are we using strings of 'r,g,b' as keys when we could very easily just use the ids of the colors