### PR TITLE
Fix incorrect pixel count on reload

### DIFF
--- a/src/templateManager.js
+++ b/src/templateManager.js
@@ -605,7 +605,7 @@ export default class TemplateManager {
                     if (a < 64) { continue; }
                     if (r === 222 && g === 250 && b === 206) { continue; }
                     requiredPixelCount++;
-                    const key = activeTemplate.allowedColorsSet.has(`${r},${g},${b}`) ? `${r},${g},${b}` : 'other';
+                    const key = Object.hasOwn(templates[templateKey].palette, `${r},${g},${b}`) ? `${r},${g},${b}` : "other";
                     paletteMap.set(key, (paletteMap.get(key) || 0) + 1);
                   }
                 }


### PR DESCRIPTION
This pull request fixes the bugs mentioned in #279.

The problem was that the `activeTemplate` variable was not defined in the `#parseBlueMarble()` function, since we're operating on a parsed JSON string rather than an instance of a Template object. This caused the script to throw an error when it tried to execute a line of code referencing the undefined variable, so control was passed to the `catch` branch after the first iteration of the loop. This meant that `requiredPixelCount` was not incremented to the correct value, breaking all code that relied on the value being correct, including the calculation of total pixels. Incidentally, this also fixes the issue of the missing list of colours.

The amended code does essentially the same thing as before, except that it finds the palette of allowed colours by considering the `templates[templateKey].palette` object instead of the undefined `activeTemplate.allowedColorsSet` property. This shouldn't have any unforeseen side-effects, knock on wood.