### PR TITLE
main.js: only intercept image/png tiles with fetch

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -99,7 +99,8 @@ inject(() => {
         .catch(err => {
           console.error(`%c${name}%c: Failed to parse JSON: `, consoleStyle, '', err);
         });
-    } else if (contentType.includes('image/') && (!endpointName.includes('openfreemap') && !endpointName.includes('maps'))) {
+        // Only intercept 'image/png' to not break potential 'image/jpeg' tiles introduced by other userscripts
+    } else if (contentType.includes('image/png') && (!endpointName.includes('openfreemap') && !endpointName.includes('maps'))) {
       // Fetch custom for all images but opensourcemap
 
       const blink = Date.now(); // Current time


### PR DESCRIPTION
Some other Wplace userscripts can introduce other map styles (like [WplacePlugins/Map Dark](https://github.com/autergame/WplacePlugins)'s [Maptiler satellite layer](https://github.com/autergame/WplacePlugins/blob/d6e5689e90a5734b99835f0ab95d2aadfe06b0f0/MapDark.user.js#L66)).
The problem is that `Map Dark` specifically has a Maptiler satellite style which is `image/jpeg` rather than `image/png`, and the current fetch interception works with any `image/*`, so the current code stumbles and errors trying to render the jpeg tile, breaking the entire satellite style.

This is a fix for that. The custom fetch implementation now only works with png tiles.