### PR TITLE
Optimize for loops to significantly reduce the delay in rendering after painting

### DIFF
--- a/src/templateManager.js
+++ b/src/templateManager.js
@@ -330,14 +330,12 @@ export default class TemplateManager {
 
           // Loops over all pixels in the template
           // Assigns each pixel a color (if center pixel)
-          for (let y = 0; y < tempHeight; y++) {
-            for (let x = 0; x < tempWidth; x++) {
+          for (let y = 1; y < tempHeight; y += this.drawMult) {
+            for (let x = 1; x < tempWidth; x += this.drawMult) {
               // Purpose: Count which pixels are painted correctly???
 
               // Only evaluate the center pixel of each shread block
               // Skip if not the center pixel of the shread block
-              if ((x % this.drawMult) !== 1 || (y % this.drawMult) !== 1) { continue; }
-
               const gx = x + offsetX;
               const gy = y + offsetY;
 
@@ -442,11 +440,9 @@ export default class TemplateManager {
           const data = img.data;
 
           // For every pixel...
-          for (let y = 0; y < tempH; y++) {
-            for (let x = 0; x < tempW; x++) {
-
+          for (let y = 1; y < tempH; y += this.drawMult) {
+            for (let x = 1; x < tempW; x += this.drawMult) {
               // If this pixel is NOT the center pixel, then skip the pixel
-              if ((x % this.drawMult) !== 1 || (y % this.drawMult) !== 1) { continue; }
 
               const idx = (y * tempW + x) * 4;
               const r = data[idx];
@@ -593,10 +589,9 @@ export default class TemplateManager {
                 cx.clearRect(0, 0, w, h);
                 cx.drawImage(templateBitmap, 0, 0);
                 const data = cx.getImageData(0, 0, w, h).data;
-                for (let y = 0; y < h; y++) {
-                  for (let x = 0; x < w; x++) {
+                for (let y = 1; y < h; y += this.drawMult) {
+                  for (let x = 1; x < w; x += this.drawMult) {
                     // Only count center pixels of 3x blocks
-                    if ((x % this.drawMult) !== 1 || (y % this.drawMult) !== 1) { continue; }
                     const idx = (y * w + x) * 4;
                     const r = data[idx];
                     const g = data[idx + 1];


### PR DESCRIPTION
As I am working on my own branch that displays tiles as 5x5 (4x4 for Mobile Safari due to 4096x4096 restriction) using crosshair indicators instead, I noticed the time required to render the tiles after intercepting the `png` requests is largely due to those redundant skipped for-loops.

For example, in the case of 3x3 drawMult, 8 out of 9 loops are skipped while the increment operations `x++` and `y++` and all those `% this.drawMult` still sums up to an expensive amount of computational time despite `continue;` being executed early.

This PR attempts to minimalize redundant iterations by replacing the for-loop statements and thus removing the need to do the remainder check after so. Tested on my own custom feature branch.