### PR TITLE
Fix coords display in pixel overview after UI update

### DIFF
--- a/src/apiManager.js
+++ b/src/apiManager.js
@@ -5,7 +5,7 @@
  */
 
 import TemplateManager from "./templateManager.js";
-import { consoleError, escapeHTML, localizeNumber, numberToEncoded, serverTPtoDisplayTP } from "./utils.js";
+import { consoleError, escapeHTML, localizeNumber, numberToEncoded } from "./utils.js";
 
 export default class ApiManager {
 
@@ -106,13 +106,12 @@ export default class ApiManager {
           }
           
           this.coordsTilePixel = [...coordsTile, ...coordsPixel]; // Combines the two arrays such that [x, y, x, y]
-          const displayTP = serverTPtoDisplayTP(coordsTile, coordsPixel);
           
-          const spanElements = document.querySelectorAll('span'); // Retrieves all span elements
+          const buttonElements = document.querySelectorAll('button'); // Retrieves all button elements
 
-          // For every span element, find the one we want (pixel numbers when canvas clicked)
-          for (const element of spanElements) {
-            if (element.textContent.trim().includes(`${displayTP[0]}, ${displayTP[1]}`)) {
+          // For every button element, find the one we want (paint button)
+          for (const element of buttonElements) {
+            if (element.textContent.trim().includes('Paint')) {
 
               let displayCoords = document.querySelector('#bm-display-coords'); // Find the additional pixel coords span
 
@@ -124,7 +123,7 @@ export default class ApiManager {
                 displayCoords.id = 'bm-display-coords';
                 displayCoords.textContent = text;
                 displayCoords.style = 'margin-left: calc(var(--spacing)*3); font-size: small;';
-                element.parentNode.parentNode.insertAdjacentElement('afterend', displayCoords);
+                element.parentNode.insertAdjacentElement('beforebegin', displayCoords);
               } else {
                 displayCoords.textContent = text;
               }


### PR DESCRIPTION
this PR moves the coords span to be over the Paint button as that's really the only place that won't break and looks fine in the new ui i think
before:
<img width="542" height="196" alt="image" src="https://github.com/user-attachments/assets/005f0a4f-414d-4223-b5d4-b3e9f8c56a5c" />
after:
<img width="542" height="196" alt="image" src="https://github.com/user-attachments/assets/27d28bdf-ad99-4554-a0a2-580fa4d1e188" />
